### PR TITLE
Fixes and cleanups

### DIFF
--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 
+from collections import Counter
 from sklearn.linear_model import LogisticRegression
 from nltk.classify.scikitlearn import SklearnClassifier
 import stanford_parse
-from collections import Counter
 
 DATA = {}
 

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -13,11 +13,16 @@ DATA = {}
 # 3. file with the lemma and pos of the words (nucle_frag_lpos.txt)
 # 4. file with the parse trees produced by the Stanford Parser (nucle_frag_trees.txt)
 
-DATA['nucle_frag_f'] = ['../data/nucle_frag_model.txt','../data/nucle_frag.txt']
+DATA['nucle_frag_f'] = ['../data/nucle_frag_model.txt', '../data/nucle_frag.txt']
 
-best_ratio = {'sva':[1,1,1,1],'cs':[1,1,1,1],'frag':[1,1,1,1],'mp':[1,1,1,1]}
+best_ratio = {
+    'sva': [1, 1, 1, 1],
+    'cs': [1, 1, 1, 1],
+    'frag': [1, 1, 1, 1],
+    'mp': [1, 1, 1, 1],
+}
 
-prob_list = [0.5,0.55,0.6,0.65,0.7,0.75,0.8,0.85,0.9,0.95]
+prob_list = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
 
 
 FIND_HEAD_DICT = {'ADJP':(0,['NNS','QP','NN','ADVP','JJ','VBN','VBG','ADJP','JJR','NP','JJS','DT','FW','RBR','RBS','SBAR','RB']),'ADVP':(1,['RB','RBR','RBS','FW','ADVP','TO','CD','JJR','JJ','IN','NP','JJS','NN']),'CONJP':(1,['CC','RB','IN']),'FRAG':(1,[]),'INTJ':(0,[]),'LST':(1,['LS']),'NAC':(0,['NN','NNS','NNP','NNPS','NP','NAC','EX','CD','QP','PRP','VBG','JJ','JJS','JJR','ADJP','FW']),'PP':(1,['IN','TO','VBG','VBN','RP','FW']),'PRN':(0,[]),'PRT':(1,['RP']),'QP':(0,['$','IN','NNS','NN','JJ','RB','DT','CD','NCD','QP','JJR','JJS']),'RRC':(1,['VP','NP','ADVP','ADJP','PP']),'S':(0,['TO','IN','VP','S','SBAR','ADJP','UCP','NP']),'SBAR':(0,['WHNP','WHPP','WHADVP','WHADJP','IN','DT','S','SQ','SINV','SBAR','FRAG']),'SBARQ':(0,['SQ','S','SINV','SBARQ','FRAG']),'SINV':(0,['VBZ','VBD','VBP','VB','MD','VP','S','SINV','ADJP','NP']),'SQ':(0,['VBZ','VBD','VBP','VB','MD','VP','SQ']),'UCP':(1,[]),'VP':(0,['TO','VBD','VBN','MD','VBZ','VB','VBG','VBP','VP','ADJP','NN','NNS','NP']),'WHADJP':(0,['CC','WRB','JJ','ADJP']),'WHADVP':(1,['CC','WRB']),'WHNP':(0,['WDT','WP','WP$','WHADJP','WHPP','WHNP']),'WHPP':(1,['IN','TO','FW'])}
@@ -27,30 +32,30 @@ print_error = False
 
 filter_threshold = 75
 
-def encode_features(data,freq_required=1):
+def encode_features(data, freq_required=1):
 	features_count = Counter()
 	for x in data:
 		for y in x[0]:
 			features_count[y] += 1
 	features_set = [x for x in features_count.keys() if features_count[x]>=freq_required]
 	print( "number of features: {}".format(len(features_set)) )
-	return (features_set,encode_features_with_feature_set(data,features_set))
+	return (features_set, encode_features_with_feature_set(data, features_set))
 
-def encode_features_with_feature_set(data,features_set):
+def encode_features_with_feature_set(data, features_set):
 	all_features_results = []
 	for x in data:
 		features = {}
 		for f in features_set:
 			features[f] = 1 if f in x[0] else 0
-		all_features_results.append((features,x[1]))
+		all_features_results.append((features, x[1]))
 	return all_features_results
 
 def train_maxent(training_data):
 	print( "training..." )
-	features_set,all_features_results = encode_features(training_data,filter_threshold)
-	classifier = SklearnClassifier(LogisticRegression(C=1.0,class_weight='balanced'))
+	features_set, all_features_results = encode_features(training_data, filter_threshold)
+	classifier = SklearnClassifier(LogisticRegression(C=1.0, class_weight='balanced'))
 	classifier.train(all_features_results)
-	return (features_set,classifier)
+	return (features_set, classifier)
 
 def precision_recall_accuracy(counts):
 	t_count = counts[0]
@@ -79,7 +84,7 @@ def precision_recall_accuracy(counts):
 	print( "A" )
 	print( "{:.2f}".format(float(float(a_count)/all_count)) )
 
-def test_maxent(classifier,features_set,data):
+def test_maxent(classifier, features_set, data):
 	print( "testing..." )
 	
 	sig_out = []
@@ -89,11 +94,11 @@ def test_maxent(classifier,features_set,data):
 	a_count = 0
 	all_count = 0
 
-	all_features_results = encode_features_with_feature_set(data,features_set)
+	all_features_results = encode_features_with_feature_set(data, features_set)
 	system_results = classifier.classify_many([x[0] for x in all_features_results])
 
 	ind = 0
-	for f,model_result in all_features_results:
+	for f, model_result in all_features_results:
 		system_result = system_results.pop(0)
 		if model_result == '1':
 			m_count += 1
@@ -112,17 +117,17 @@ def test_maxent(classifier,features_set,data):
 		all_count += 1
 		if system_result == model_result:
 			a_count += 1
-			sig_out.append('{}\t{}\t{}'.format(system_result,model_result,'1'))
+			sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '1'))
 		else:
-			sig_out.append('{}\t{}\t{}'.format(system_result,model_result,'0'))
+			sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '0'))
 		ind += 1
-	precision_recall_accuracy([t_count,m_count,c_count,a_count,all_count])	
+	precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])	
 	return sig_out
 
-def test_maxent_prob(classifier,features_set,data):
+def test_maxent_prob(classifier, features_set, data):
 	print( "testing..." )
 	sig_out = []
-	all_features_results = encode_features_with_feature_set(data,features_set)
+	all_features_results = encode_features_with_feature_set(data, features_set)
 	system_results_ori = classifier.prob_classify_many([x[0] for x in all_features_results])
 	for t in prob_list:
 		print( "Probability > {}".format(t) )
@@ -133,7 +138,7 @@ def test_maxent_prob(classifier,features_set,data):
 		all_count = 0
 		ind = 0
 		system_results = system_results_ori[:]
-		for f,model_result in all_features_results:
+		for f, model_result in all_features_results:
 			system_result = '1' if system_results.pop(0).prob('1') > t else '0'
 			if model_result == '1':
 				m_count += 1
@@ -152,7 +157,7 @@ def test_maxent_prob(classifier,features_set,data):
 			else:
 				sig_out.append('0')
 			ind += 1
-		precision_recall_accuracy([t_count,m_count,c_count,a_count,all_count])	
+		precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])	
 	return sig_out
 
 def find_node_from_list(children_list, node_list):
@@ -168,15 +173,15 @@ def find_head_of_NP(n):
 		if n.children[-1].label == 'POS':
 			head = n.children[-1]
 		if not head:
-			head = find_node_from_list(n_children_reverse,['NN','NNP','NNPS','NNS','NX','POS','JJR'])
+			head = find_node_from_list(n_children_reverse, ['NN', 'NNP', 'NNPS', 'NNS', 'NX', 'POS', 'JJR'])
 		if not head:
-			head = find_node_from_list(n.children,['NP'])
+			head = find_node_from_list(n.children, ['NP'])
 		if not head:
-			head = find_node_from_list(n_children_reverse,['ADJP','PRN'])
+			head = find_node_from_list(n_children_reverse, ['ADJP', 'PRN'])
 		if not head:
-			head = find_node_from_list(n_children_reverse,['CD'])
+			head = find_node_from_list(n_children_reverse, ['CD'])
 		if not head:
-			head = find_node_from_list(n_children_reverse,['JJ','JJS','RB','QP'])
+			head = find_node_from_list(n_children_reverse, ['JJ', 'JJS', 'RB', 'QP'])
 		if not head:
 			head = n.children[-1]	
 	return head
@@ -210,9 +215,9 @@ def find_head(n):
 		return None
 
 
-def convert_noun_pos(pos_label,word):
+def convert_noun_pos(pos_label, word):
 	if pos_label == 'PRP':
-		if word.lower() in ['i','you','we','they']:
+		if word.lower() in ['i', 'you', 'we', 'they']:
 			pos_label = 'NNS'
 		else:
 			pos_label = 'NN'
@@ -223,14 +228,14 @@ def convert_noun_pos(pos_label,word):
 	return pos_label
 
 
-def get_node_with_pos(n,lpos,tagger_output,get_word=False):
+def get_node_with_pos(n, lpos, tagger_output, get_word=False):
 	temp = None
-	if n.label in ['VP','NP','ADVP','ADJP']:
+	if n.label in ['VP', 'NP', 'ADVP', 'ADJP']:
 		temp = find_head(n)
 	if temp:
 		if tagger_output:
 			if convert_noun:
-				return n.label + '|' + convert_noun_pos(lpos[temp.word_index-1][1],lpos[temp.word_index-1][0])
+				return n.label + '|' + convert_noun_pos(lpos[temp.word_index-1][1], lpos[temp.word_index-1][0])
 			else:
 				if get_word and n.label == 'NP':
 				# if get_word:
@@ -239,35 +244,35 @@ def get_node_with_pos(n,lpos,tagger_output,get_word=False):
 					return n.label + '|' + lpos[temp.word_index-1][1]
 		else:
 			if convert_noun:
-				return n.label + '|' + convert_noun_pos(temp.label,lpos[temp.word_index-1][0])
+				return n.label + '|' + convert_noun_pos(temp.label, lpos[temp.word_index-1][0])
 			else:
 				return n.label + '|' + temp.label
 	else:
 		return n.label
 
 
-def find_s(n,path):
+def find_s(n, path):
 	path.append(n.id)
 	if n.parent_n:
-		if n.parent_n.label in ['S','SBAR','SINV','FRAG']:
-			return (n.parent_n,path)
+		if n.parent_n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
+			return (n.parent_n, path)
 		else:
-			return find_s(n.parent_n,path)
+			return find_s(n.parent_n, path)
 	else:
-		return (n,path)
+		return (n, path)
 
-def get_trigram(i,l,prefix):
+def get_trigram(i, l, prefix):
 	prev_t = l[i-1] if i-1>=0 else '<start>'
 	next_t = l[i+1] if i+1<len(l) else '<end>'
 	mid_t = l[i] if i<len(l) else '<mid>'
-	return (prefix + ':' + '_'.join([prev_t,mid_t,next_t]),[prev_t,mid_t,next_t])
+	return (prefix + ':' + '_'.join([prev_t, mid_t, next_t]), [prev_t, mid_t, next_t])
 
-def process_files_whole_sentence(sentences,sentences_lpos,sentences_trees):
+def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
 	all_instances = []
 	sentence_id = 0
 	tagger_output = True
-	for sentence,lpos,tree in zip(sentences,sentences_lpos,sentences_trees):
-		sentence_ori = sentence.replace('*','').split(' ')
+	for sentence, lpos, tree in zip(sentences, sentences_lpos, sentences_trees):
+		sentence_ori = sentence.replace('*', '').split(' ')
 		sentence = sentence.split(' ')
 		lpos_all = [x.split('|') for x in lpos.split(' ')]
 		lpos = [x.split('|')[1] for x in lpos.split(' ')]
@@ -275,16 +280,16 @@ def process_files_whole_sentence(sentences,sentences_lpos,sentences_trees):
 		
 		instance_features = []
 
-		for i in range(0,len(sentence)):
+		for i in range(0, len(sentence)):
 			if include_wordtrigram:
-				wordtrigram = get_trigram(i,sentence_ori,'WORDTRI')
+				wordtrigram = get_trigram(i, sentence_ori, 'WORDTRI')
 				instance_features.append(wordtrigram[0])
 				instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][:2]))
 				instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][1:]))
 				instance_features.append('WORDTRI:' + wordtrigram[1][1])
 
 			if include_postrigram:
-				postrigram = get_trigram(i,lpos,'POSTRI')
+				postrigram = get_trigram(i, lpos, 'POSTRI')
 				instance_features.append(postrigram[0])
 				instance_features.append('POSTRI:' + '_'.join(postrigram[1][:2]))
 				instance_features.append('POSTRI:' + '_'.join(postrigram[1][1:]))
@@ -292,7 +297,7 @@ def process_files_whole_sentence(sentences,sentences_lpos,sentences_trees):
 
 		if include_nodetrigram:
 			for n in nodes:
-				if n.label in ['S','SBAR','SINV','FRAG']:
+				if n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
 					s_node = n
 					node_indexs = range(len(s_node.children))
 					for i in node_indexs:
@@ -300,18 +305,18 @@ def process_files_whole_sentence(sentences,sentences_lpos,sentences_trees):
 						temp_word_trigram = []
 						temp_node_trigram = []
 						if i-1>=0:
-							temp_trigram.append(get_node_with_pos(s_node.children[i-1],lpos_all,tagger_output))
-							temp_word_trigram.append(get_node_with_pos(s_node.children[i-1],lpos_all,tagger_output,True))
+							temp_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output))
+							temp_word_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output, True))
 							temp_node_trigram.append(s_node.children[i-1])
 						else:
 							temp_trigram.append('<start>')
 							temp_word_trigram.append('<start>')
-						temp_trigram.append(get_node_with_pos(s_node.children[i],lpos_all,tagger_output))
-						temp_word_trigram.append(get_node_with_pos(s_node.children[i],lpos_all,tagger_output,True))
+						temp_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output))
+						temp_word_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output, True))
 						temp_node_trigram.append(s_node.children[i])
 						if i+1<len(s_node.children):
-							temp_trigram.append(get_node_with_pos(s_node.children[i+1],lpos_all,tagger_output))
-							temp_word_trigram.append(get_node_with_pos(s_node.children[i+1],lpos_all,tagger_output,True))
+							temp_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output))
+							temp_word_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output, True))
 							temp_node_trigram.append(s_node.children[i+1])
 						else:
 							temp_trigram.append('<end>')
@@ -333,39 +338,39 @@ def process_files_whole_sentence(sentences,sentences_lpos,sentences_trees):
 		if '*' in ' '.join(sentence):
 			sva_flag = '1'
 		instance_features = list(set(instance_features))
-		all_instances.append((instance_features,sva_flag,sentence_id,0,sentence))
+		all_instances.append((instance_features, sva_flag, sentence_id, 0, sentence))
 		sentence_id += 1
 	return all_instances
 
-def process_files(file_list,feature_function,filter_func=None,neg_pos_ratio=1,no_of_sentence=10000,start_from=0):
+def process_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0):
 	print( "processing file {}...".format(file_list[0]) )
 	sentences = open(file_list[0]).read().splitlines()
-	sentences_lpos = open(file_list[1].replace('.txt','_lpos.txt')).read().splitlines()
-	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt','_trees.txt')).read())
+	sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
+	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
 	if filter_func:
-		sentences,sentences_lpos,sentences_trees = filter_func(sentences,sentences_lpos,sentences_trees,
-													  neg_pos_ratio,no_of_sentence,start_from)
-	return feature_function(sentences,sentences_lpos,sentences_trees)
+		sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees,
+													  neg_pos_ratio, no_of_sentence, start_from)
+	return feature_function(sentences, sentences_lpos, sentences_trees)
 
-def process_training_files(file_list,feature_function,filter_func=None,neg_pos_ratio=1,no_of_sentence=10000,start_from=0,align=False):
+def process_training_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0, align=False):
 	print( "processing file {}...".format(file_list[0]) )
 	no_of_sentence_for_preprocess = 18000
 	sentences = open(file_list[0]).read().splitlines()
-	sentences_lpos = open(file_list[1].replace('.txt','_lpos.txt')).read().splitlines()
-	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt','_trees.txt')).read())
+	sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
+	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
 	
 	no_of_pos = no_of_sentence/(neg_pos_ratio+1)
 	no_of_neg = no_of_pos * neg_pos_ratio
 
 	if filter_func:
-		sentences,sentences_lpos,sentences_trees = filter_func(sentences,sentences_lpos,sentences_trees,
-													  1,no_of_sentence_for_preprocess,start_from)
-	all_instances = feature_function(sentences,sentences_lpos,sentences_trees)
+		sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees,
+													  1, no_of_sentence_for_preprocess, start_from)
+	all_instances = feature_function(sentences, sentences_lpos, sentences_trees)
 	if align:
-		aligned_file = open(file_list[1].replace('.txt','_align.txt')).read().splitlines()
+		aligned_file = open(file_list[1].replace('.txt', '_align.txt')).read().splitlines()
 		aligned_file = [x.split(' ') for x in aligned_file]
 
-	all_instances = dict([((x[2],x[3]),x) for x in all_instances])
+	all_instances = dict([((x[2], x[3]), x) for x in all_instances])
 
 	filtered_all_instances = []
 	neg_instances = []
@@ -376,9 +381,9 @@ def process_training_files(file_list,feature_function,filter_func=None,neg_pos_r
 			else:
 				aligned_sent = x[0]+1
 			aligned_ind = int(aligned_file[x[0]][x[1]])
-			if (aligned_sent,aligned_ind) in all_instances.keys():
+			if (aligned_sent, aligned_ind) in all_instances.keys():
 				current_instance = all_instances[x]
-				aligned_instance = all_instances[(aligned_sent,aligned_ind)]
+				aligned_instance = all_instances[(aligned_sent, aligned_ind)]
 				if current_instance[1] != aligned_instance[1]:
 					current_local_features = [x for x in current_instance[0] if "WORDTRI:" in x or "POSTRI:" in x]
 					current_parse_features = [x for x in current_instance[0] if "WORDTRI:" not in x and "POSTRI:" not in x]
@@ -401,7 +406,7 @@ def process_training_files(file_list,feature_function,filter_func=None,neg_pos_r
 	return filtered_all_instances
 
 
-def training_data_filter(sentences,sentences_lpos,sentences_trees,neg_pos_ratio,no_of_sentence,start_from):
+def training_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from):
 	new_sentences = []
 	new_sentences_lpos = []
 	new_sentences_trees = []
@@ -411,7 +416,7 @@ def training_data_filter(sentences,sentences_lpos,sentences_trees,neg_pos_ratio,
 	count = 0
 	pos_count = 0
 	neg_count = 0
-	for sentence,lpos,tree in zip(sentences[start_from:],sentences_lpos[start_from:],sentences_trees[start_from:]):
+	for sentence, lpos, tree in zip(sentences[start_from:], sentences_lpos[start_from:], sentences_trees[start_from:]):
 		if no_of_pos == 0 and no_of_neg == 0:
 			break
 		if '*' in sentence:
@@ -436,10 +441,10 @@ def training_data_filter(sentences,sentences_lpos,sentences_trees,neg_pos_ratio,
 	print( start_from )
 	print( count	 )
 	print( start_from + count )
-	return (new_sentences,new_sentences_lpos,new_sentences_trees)
+	return (new_sentences, new_sentences_lpos, new_sentences_trees)
 
-def nucle_data_filter(sentences,sentences_lpos,sentences_trees,neg_pos_ratio,no_of_sentence,start_from):
-	return (sentences,sentences_lpos,sentences_trees)
+def nucle_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from):
+	return (sentences, sentences_lpos, sentences_trees)
 
 def show_most_informative_features_binary(vectorizer, clf, n=20):
     feature_names = vectorizer.get_feature_names()
@@ -464,12 +469,12 @@ if __name__ == '__main__':
 	print( 'word: {}'.format(include_wordtrigram) )
 	print( 'pos: {}'.format(include_postrigram) )
 	print( 'node: {}'.format(include_nodetrigram) )
-	all_instances = process_files(DATA['nucle_frag_f'],feauture_function,training_data_filter,neg_pos_ratio=r)
-	features_set,classifier = train_maxent(all_instances)
+	all_instances = process_files(DATA['nucle_frag_f'], feauture_function, training_data_filter, neg_pos_ratio=r)
+	features_set, classifier = train_maxent(all_instances)
 	
 
-	show_most_informative_features_binary(classifier._vectorizer,classifier._clf,n=100)
+	show_most_informative_features_binary(classifier._vectorizer, classifier._clf, n=100)
 
-	all_instances = process_files(DATA['nucle_frag_f'],feauture_function)
+	all_instances = process_files(DATA['nucle_frag_f'], feauture_function)
 
-	sig_out = test_maxent(classifier,features_set,all_instances)
+	sig_out = test_maxent(classifier, features_set, all_instances)

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -61,7 +61,7 @@ def encode_features(data, freq_required=1):
     for x in data:
         for y in x[0]:
             features_count[y] += 1
-    features_set = [x for x in features_count.keys() if features_count[x]>=freq_required]
+    features_set = [x for x in features_count.keys() if features_count[x] >= freq_required]
     print( "number of features: {}".format(len(features_set)) )
     return (features_set, encode_features_with_feature_set(data, features_set))
 
@@ -193,7 +193,7 @@ def find_head_of_NP(n):
     head = None
     n_children_reverse = n.children[:]
     n_children_reverse.reverse()
-    if len(n.children)>0:
+    if len(n.children) > 0:
         if n.children[-1].label == 'POS':
             head = n.children[-1]
         if not head:
@@ -286,9 +286,9 @@ def find_s(n, path):
         return (n, path)
 
 def get_trigram(i, l, prefix):
-    prev_t = l[i-1] if i-1>=0 else '<start>'
-    next_t = l[i+1] if i+1<len(l) else '<end>'
-    mid_t = l[i] if i<len(l) else '<mid>'
+    prev_t = l[i-1] if i-1 >= 0 else '<start>'
+    next_t = l[i+1] if i+1 < len(l) else '<end>'
+    mid_t = l[i] if i < len(l) else '<mid>'
     return (prefix + ':' + '_'.join([prev_t, mid_t, next_t]), [prev_t, mid_t, next_t])
 
 def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
@@ -328,7 +328,7 @@ def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
                         temp_trigram = []
                         temp_word_trigram = []
                         temp_node_trigram = []
-                        if i-1>=0:
+                        if i-1 >= 0:
                             temp_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output))
                             temp_word_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output, True))
                             temp_node_trigram.append(s_node.children[i-1])
@@ -338,7 +338,7 @@ def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
                         temp_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output))
                         temp_word_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output, True))
                         temp_node_trigram.append(s_node.children[i])
-                        if i+1<len(s_node.children):
+                        if i+1 < len(s_node.children):
                             temp_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output))
                             temp_word_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output, True))
                             temp_node_trigram.append(s_node.children[i+1])

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -62,7 +62,7 @@ def encode_features(data, freq_required=1):
         for y in x[0]:
             features_count[y] += 1
     features_set = [x for x in features_count.keys() if features_count[x] >= freq_required]
-    print( "number of features: {}".format(len(features_set)) )
+    print("number of features: {}".format(len(features_set)))
     return (features_set, encode_features_with_feature_set(data, features_set))
 
 def encode_features_with_feature_set(data, features_set):
@@ -75,7 +75,7 @@ def encode_features_with_feature_set(data, features_set):
     return all_features_results
 
 def train_maxent(training_data):
-    print( "training..." )
+    print("training...")
     features_set, all_features_results = encode_features(training_data, filter_threshold)
     classifier = SklearnClassifier(LogisticRegression(C=1.0, class_weight='balanced'))
     classifier.train(all_features_results)
@@ -97,19 +97,19 @@ def precision_recall_accuracy(counts):
     else:
         R = 0
 
-    print( "# model: {}".format(m_count) )
-    print( "# test: {}".format(t_count) )
-    print( "# correct: {}".format(c_count) )
-    print( "# match: {}".format(a_count) )
-    print( "# all: {}".format(all_count) )
+    print("# model: {}".format(m_count))
+    print("# test: {}".format(t_count))
+    print("# correct: {}".format(c_count))
+    print("# match: {}".format(a_count))
+    print("# all: {}".format(all_count))
     print
-    print( "P\tR" )
-    print( "{:.2f}\t{:.2f}".format(P, R) )
-    print( "A" )
-    print( "{:.2f}".format(float(float(a_count)/all_count)) )
+    print("P\tR")
+    print("{:.2f}\t{:.2f}".format(P, R))
+    print("A")
+    print("{:.2f}".format(float(float(a_count)/all_count)))
 
 def test_maxent(classifier, features_set, data):
-    print( "testing..." )
+    print("testing...")
 
     sig_out = []
     t_count = 0
@@ -133,10 +133,10 @@ def test_maxent(classifier, features_set, data):
         if print_error and model_result != system_result:
             t_sentence = data[ind][4][:]
             t_sentence[data[ind][3]] = '[' + t_sentence[data[ind][3]] + ']'
-            print( ' '.join(t_sentence) )
-            print( 'model: ' + model_result )
-            print( 'system: ' + system_result )
-            print( [x for x in data[ind][0] if x in features_set] )
+            print(' '.join(t_sentence))
+            print('model: ' + model_result)
+            print('system: ' + system_result)
+            print([x for x in data[ind][0] if x in features_set])
             print
         all_count += 1
         if system_result == model_result:
@@ -149,12 +149,12 @@ def test_maxent(classifier, features_set, data):
     return sig_out
 
 def test_maxent_prob(classifier, features_set, data):
-    print( "testing..." )
+    print("testing...")
     sig_out = []
     all_features_results = encode_features_with_feature_set(data, features_set)
     system_results_ori = classifier.prob_classify_many([x[0] for x in all_features_results])
     for t in prob_list:
-        print( "Probability > {}".format(t) )
+        print("Probability > {}".format(t))
         t_count = 0
         m_count = 0
         c_count = 0
@@ -367,7 +367,7 @@ def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
     return all_instances
 
 def process_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0):
-    print( "processing file {}...".format(file_list[0]) )
+    print("processing file {}...".format(file_list[0]))
     sentences = open(file_list[0]).read().splitlines()
     sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
     sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
@@ -376,7 +376,7 @@ def process_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1
     return feature_function(sentences, sentences_lpos, sentences_trees)
 
 def process_training_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0, align=False):
-    print( "processing file {}...".format(file_list[0]) )
+    print("processing file {}...".format(file_list[0]))
     no_of_sentence_for_preprocess = 18000
     sentences = open(file_list[0]).read().splitlines()
     sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
@@ -421,9 +421,9 @@ def process_training_files(file_list, feature_function, filter_func=None, neg_po
                     else:
                         break
 
-    print( "Training data (filtered):" )
-    print( "no of pos: {}".format(len(filtered_all_instances)) )
-    print( "no of neg: {}".format(len(neg_instances)) )
+    print("Training data (filtered):")
+    print("no of pos: {}".format(len(filtered_all_instances)))
+    print("no of neg: {}".format(len(neg_instances)))
     filtered_all_instances += neg_instances
     return filtered_all_instances
 
@@ -434,7 +434,7 @@ def training_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_rat
     new_sentences_trees = []
     no_of_pos = round(no_of_sentence/(neg_pos_ratio+1))
     no_of_neg = round(no_of_pos * neg_pos_ratio)
-    print( "Training data (preprocess):" )
+    print("Training data (preprocess):")
     count = 0
     pos_count = 0
     neg_count = 0
@@ -457,12 +457,12 @@ def training_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_rat
                 neg_count += 1
         count += 1
 
-    print( "no of pos: {}".format(pos_count) )
-    print( "no of neg: {}".format(neg_count)         )
-    print( len(new_sentences) )
-    print( start_from )
-    print( count     )
-    print( start_from + count )
+    print("no of pos: {}".format(pos_count))
+    print("no of neg: {}".format(neg_count))
+    print(len(new_sentences))
+    print(start_from)
+    print(count)
+    print(start_from + count)
     return (new_sentences, new_sentences_lpos, new_sentences_trees)
 
 def nucle_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from):
@@ -472,9 +472,9 @@ def show_most_informative_features_binary(vectorizer, clf, n=20):
     feature_names = vectorizer.get_feature_names()
     coefs_with_fns = sorted(zip(clf.coef_[0], feature_names))
     top = zip(coefs_with_fns[:n], coefs_with_fns[:-(n + 1):-1])
-    print( clf.classes_ )
+    print(clf.classes_)
     for (coef_1, fn_1), (coef_2, fn_2) in top:
-        print( "\t%.4f\t%-15s\t\t%.4f\t%-15s" % (coef_1, fn_1, coef_2, fn_2) )
+        print("\t%.4f\t%-15s\t\t%.4f\t%-15s" % (coef_1, fn_1, coef_2, fn_2))
 
 if __name__ == '__main__':
 
@@ -487,10 +487,10 @@ if __name__ == '__main__':
     # pos_neg_ratio
     r = 1
 
-    print( "ratio: {}".format(r) )
-    print( 'word: {}'.format(include_wordtrigram) )
-    print( 'pos: {}'.format(include_postrigram) )
-    print( 'node: {}'.format(include_nodetrigram) )
+    print("ratio: {}".format(r))
+    print('word: {}'.format(include_wordtrigram))
+    print('pos: {}'.format(include_postrigram))
+    print('node: {}'.format(include_nodetrigram))
     all_instances = process_files(DATA['nucle_frag_f'], feauture_function, training_data_filter, neg_pos_ratio=r)
     features_set, classifier = train_maxent(all_instances)
 

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -33,418 +33,416 @@ print_error = False
 filter_threshold = 75
 
 def encode_features(data, freq_required=1):
-	features_count = Counter()
-	for x in data:
-		for y in x[0]:
-			features_count[y] += 1
-	features_set = [x for x in features_count.keys() if features_count[x]>=freq_required]
-	print( "number of features: {}".format(len(features_set)) )
-	return (features_set, encode_features_with_feature_set(data, features_set))
+    features_count = Counter()
+    for x in data:
+        for y in x[0]:
+            features_count[y] += 1
+    features_set = [x for x in features_count.keys() if features_count[x]>=freq_required]
+    print( "number of features: {}".format(len(features_set)) )
+    return (features_set, encode_features_with_feature_set(data, features_set))
 
 def encode_features_with_feature_set(data, features_set):
-	all_features_results = []
-	for x in data:
-		features = {}
-		for f in features_set:
-			features[f] = 1 if f in x[0] else 0
-		all_features_results.append((features, x[1]))
-	return all_features_results
+    all_features_results = []
+    for x in data:
+        features = {}
+        for f in features_set:
+            features[f] = 1 if f in x[0] else 0
+        all_features_results.append((features, x[1]))
+    return all_features_results
 
 def train_maxent(training_data):
-	print( "training..." )
-	features_set, all_features_results = encode_features(training_data, filter_threshold)
-	classifier = SklearnClassifier(LogisticRegression(C=1.0, class_weight='balanced'))
-	classifier.train(all_features_results)
-	return (features_set, classifier)
+    print( "training..." )
+    features_set, all_features_results = encode_features(training_data, filter_threshold)
+    classifier = SklearnClassifier(LogisticRegression(C=1.0, class_weight='balanced'))
+    classifier.train(all_features_results)
+    return (features_set, classifier)
 
 def precision_recall_accuracy(counts):
-	t_count = counts[0]
-	m_count = counts[1]
-	c_count = counts[2]
-	a_count = counts[3]
-	all_count = counts[4]
+    t_count = counts[0]
+    m_count = counts[1]
+    c_count = counts[2]
+    a_count = counts[3]
+    all_count = counts[4]
 
-	if t_count > 0:
-		P = float(c_count)/t_count
-	else:
-		P = 0
-	if m_count > 0:
-		R = float(c_count)/m_count
-	else:
-		R = 0
+    if t_count > 0:
+        P = float(c_count)/t_count
+    else:
+        P = 0
+    if m_count > 0:
+        R = float(c_count)/m_count
+    else:
+        R = 0
 
-	print( "# model: {}".format(m_count) )
-	print( "# test: {}".format(t_count) )
-	print( "# correct: {}".format(c_count) )
-	print( "# match: {}".format(a_count) )
-	print( "# all: {}".format(all_count) )
-	print
-	print( "P\tR" )
-	print( "{:.2f}\t{:.2f}".format(P, R) )
-	print( "A" )
-	print( "{:.2f}".format(float(float(a_count)/all_count)) )
+    print( "# model: {}".format(m_count) )
+    print( "# test: {}".format(t_count) )
+    print( "# correct: {}".format(c_count) )
+    print( "# match: {}".format(a_count) )
+    print( "# all: {}".format(all_count) )
+    print
+    print( "P\tR" )
+    print( "{:.2f}\t{:.2f}".format(P, R) )
+    print( "A" )
+    print( "{:.2f}".format(float(float(a_count)/all_count)) )
 
 def test_maxent(classifier, features_set, data):
-	print( "testing..." )
-	
-	sig_out = []
-	t_count = 0
-	m_count = 0
-	c_count = 0
-	a_count = 0
-	all_count = 0
+    print( "testing..." )
 
-	all_features_results = encode_features_with_feature_set(data, features_set)
-	system_results = classifier.classify_many([x[0] for x in all_features_results])
+    sig_out = []
+    t_count = 0
+    m_count = 0
+    c_count = 0
+    a_count = 0
+    all_count = 0
 
-	ind = 0
-	for f, model_result in all_features_results:
-		system_result = system_results.pop(0)
-		if model_result == '1':
-			m_count += 1
-		if system_result == '1':
-			t_count += 1
-			if model_result == '1':
-				c_count += 1
-		if print_error and model_result != system_result:
-			t_sentence = data[ind][4][:]
-			t_sentence[data[ind][3]] = '[' + t_sentence[data[ind][3]] + ']'
-			print( ' '.join(t_sentence) )
-			print( 'model: ' + model_result )
-			print( 'system: ' + system_result )
-			print( [x for x in data[ind][0] if x in features_set] )
-			print
-		all_count += 1
-		if system_result == model_result:
-			a_count += 1
-			sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '1'))
-		else:
-			sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '0'))
-		ind += 1
-	precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])	
-	return sig_out
+    all_features_results = encode_features_with_feature_set(data, features_set)
+    system_results = classifier.classify_many([x[0] for x in all_features_results])
+
+    ind = 0
+    for f, model_result in all_features_results:
+        system_result = system_results.pop(0)
+        if model_result == '1':
+            m_count += 1
+        if system_result == '1':
+            t_count += 1
+            if model_result == '1':
+                c_count += 1
+        if print_error and model_result != system_result:
+            t_sentence = data[ind][4][:]
+            t_sentence[data[ind][3]] = '[' + t_sentence[data[ind][3]] + ']'
+            print( ' '.join(t_sentence) )
+            print( 'model: ' + model_result )
+            print( 'system: ' + system_result )
+            print( [x for x in data[ind][0] if x in features_set] )
+            print
+        all_count += 1
+        if system_result == model_result:
+            a_count += 1
+            sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '1'))
+        else:
+            sig_out.append('{}\t{}\t{}'.format(system_result, model_result, '0'))
+        ind += 1
+    precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])
+    return sig_out
 
 def test_maxent_prob(classifier, features_set, data):
-	print( "testing..." )
-	sig_out = []
-	all_features_results = encode_features_with_feature_set(data, features_set)
-	system_results_ori = classifier.prob_classify_many([x[0] for x in all_features_results])
-	for t in prob_list:
-		print( "Probability > {}".format(t) )
-		t_count = 0
-		m_count = 0
-		c_count = 0
-		a_count = 0
-		all_count = 0
-		ind = 0
-		system_results = system_results_ori[:]
-		for f, model_result in all_features_results:
-			system_result = '1' if system_results.pop(0).prob('1') > t else '0'
-			if model_result == '1':
-				m_count += 1
-			if system_result == '1':
-				t_count += 1
-				if model_result == '1':
-					c_count += 1
-			if print_error and model_result != system_result:
-				t_sentence = data[ind][4][:]
-				t_sentence[data[ind][3]] = '[' + t_sentence[data[ind][3]] + ']'
-				
-			all_count += 1
-			if system_result == model_result:
-				a_count += 1
-				sig_out.append('1')
-			else:
-				sig_out.append('0')
-			ind += 1
-		precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])	
-	return sig_out
+    print( "testing..." )
+    sig_out = []
+    all_features_results = encode_features_with_feature_set(data, features_set)
+    system_results_ori = classifier.prob_classify_many([x[0] for x in all_features_results])
+    for t in prob_list:
+        print( "Probability > {}".format(t) )
+        t_count = 0
+        m_count = 0
+        c_count = 0
+        a_count = 0
+        all_count = 0
+        ind = 0
+        system_results = system_results_ori[:]
+        for f, model_result in all_features_results:
+            system_result = '1' if system_results.pop(0).prob('1') > t else '0'
+            if model_result == '1':
+                m_count += 1
+            if system_result == '1':
+                t_count += 1
+                if model_result == '1':
+                    c_count += 1
+            if print_error and model_result != system_result:
+                t_sentence = data[ind][4][:]
+                t_sentence[data[ind][3]] = '[' + t_sentence[data[ind][3]] + ']'
+
+            all_count += 1
+            if system_result == model_result:
+                a_count += 1
+                sig_out.append('1')
+            else:
+                sig_out.append('0')
+            ind += 1
+        precision_recall_accuracy([t_count, m_count, c_count, a_count, all_count])
+    return sig_out
 
 def find_node_from_list(children_list, node_list):
-	for x in children_list:
-		if x.label in node_list:
-			return x
+    for x in children_list:
+        if x.label in node_list:
+            return x
 
 def find_head_of_NP(n):
-	head = None
-	n_children_reverse = n.children[:]
-	n_children_reverse.reverse()
-	if len(n.children)>0:
-		if n.children[-1].label == 'POS':
-			head = n.children[-1]
-		if not head:
-			head = find_node_from_list(n_children_reverse, ['NN', 'NNP', 'NNPS', 'NNS', 'NX', 'POS', 'JJR'])
-		if not head:
-			head = find_node_from_list(n.children, ['NP'])
-		if not head:
-			head = find_node_from_list(n_children_reverse, ['ADJP', 'PRN'])
-		if not head:
-			head = find_node_from_list(n_children_reverse, ['CD'])
-		if not head:
-			head = find_node_from_list(n_children_reverse, ['JJ', 'JJS', 'RB', 'QP'])
-		if not head:
-			head = n.children[-1]	
-	return head
-	
-def find_head(n):
-	out_node = None
-	if n.label in FIND_HEAD_DICT.keys():
-		target_tuple = FIND_HEAD_DICT[n.label]
-		n_children = n.children[:]
-		if target_tuple[0]:
-			n_children.reverse()
-		for l in target_tuple[1]:
-			for x in n_children:
-				if x.label == l:
-					out_node = x
-			if out_node:
-				break
-	elif n.label == 'NP':
-		out_node = find_head_of_NP(n)
+    head = None
+    n_children_reverse = n.children[:]
+    n_children_reverse.reverse()
+    if len(n.children)>0:
+        if n.children[-1].label == 'POS':
+            head = n.children[-1]
+        if not head:
+            head = find_node_from_list(n_children_reverse, ['NN', 'NNP', 'NNPS', 'NNS', 'NX', 'POS', 'JJR'])
+        if not head:
+            head = find_node_from_list(n.children, ['NP'])
+        if not head:
+            head = find_node_from_list(n_children_reverse, ['ADJP', 'PRN'])
+        if not head:
+            head = find_node_from_list(n_children_reverse, ['CD'])
+        if not head:
+            head = find_node_from_list(n_children_reverse, ['JJ', 'JJS', 'RB', 'QP'])
+        if not head:
+            head = n.children[-1]
+    return head
 
-	if not out_node:
-		if n.children:
-			out_node = n.children[0]
-		else:
-			return None
-	if out_node.label in FIND_HEAD_DICT.keys() or out_node.label == 'NP':
-		return find_head(out_node)
-	elif out_node.word:
-		return out_node
-	else:
-		return None
+def find_head(n):
+    out_node = None
+    if n.label in FIND_HEAD_DICT.keys():
+        target_tuple = FIND_HEAD_DICT[n.label]
+        n_children = n.children[:]
+        if target_tuple[0]:
+            n_children.reverse()
+        for l in target_tuple[1]:
+            for x in n_children:
+                if x.label == l:
+                    out_node = x
+            if out_node:
+                break
+    elif n.label == 'NP':
+        out_node = find_head_of_NP(n)
+
+    if not out_node:
+        if n.children:
+            out_node = n.children[0]
+        else:
+            return None
+    if out_node.label in FIND_HEAD_DICT.keys() or out_node.label == 'NP':
+        return find_head(out_node)
+    elif out_node.word:
+        return out_node
+    else:
+        return None
 
 
 def convert_noun_pos(pos_label, word):
-	if pos_label == 'PRP':
-		if word.lower() in ['i', 'you', 'we', 'they']:
-			pos_label = 'NNS'
-		else:
-			pos_label = 'NN'
-	elif pos_label == 'NNP':
-		pos_label = 'NN'
-	elif pos_label == 'NNPS':
-		pos_label = 'NNS'
-	return pos_label
+    if pos_label == 'PRP':
+        if word.lower() in ['i', 'you', 'we', 'they']:
+            pos_label = 'NNS'
+        else:
+            pos_label = 'NN'
+    elif pos_label == 'NNP':
+        pos_label = 'NN'
+    elif pos_label == 'NNPS':
+        pos_label = 'NNS'
+    return pos_label
 
 
 def get_node_with_pos(n, lpos, tagger_output, get_word=False):
-	temp = None
-	if n.label in ['VP', 'NP', 'ADVP', 'ADJP']:
-		temp = find_head(n)
-	if temp:
-		if tagger_output:
-			if convert_noun:
-				return n.label + '|' + convert_noun_pos(lpos[temp.word_index-1][1], lpos[temp.word_index-1][0])
-			else:
-				if get_word and n.label == 'NP':
-				# if get_word:
-					return n.label + '|' + lpos[temp.word_index-1][0]
-				else:
-					return n.label + '|' + lpos[temp.word_index-1][1]
-		else:
-			if convert_noun:
-				return n.label + '|' + convert_noun_pos(temp.label, lpos[temp.word_index-1][0])
-			else:
-				return n.label + '|' + temp.label
-	else:
-		return n.label
+    temp = None
+    if n.label in ['VP', 'NP', 'ADVP', 'ADJP']:
+        temp = find_head(n)
+    if temp:
+        if tagger_output:
+            if convert_noun:
+                return n.label + '|' + convert_noun_pos(lpos[temp.word_index-1][1], lpos[temp.word_index-1][0])
+            else:
+                if get_word and n.label == 'NP':
+                # if get_word:
+                    return n.label + '|' + lpos[temp.word_index-1][0]
+                else:
+                    return n.label + '|' + lpos[temp.word_index-1][1]
+        else:
+            if convert_noun:
+                return n.label + '|' + convert_noun_pos(temp.label, lpos[temp.word_index-1][0])
+            else:
+                return n.label + '|' + temp.label
+    else:
+        return n.label
 
 
 def find_s(n, path):
-	path.append(n.id)
-	if n.parent_n:
-		if n.parent_n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
-			return (n.parent_n, path)
-		else:
-			return find_s(n.parent_n, path)
-	else:
-		return (n, path)
+    path.append(n.id)
+    if n.parent_n:
+        if n.parent_n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
+            return (n.parent_n, path)
+        else:
+            return find_s(n.parent_n, path)
+    else:
+        return (n, path)
 
 def get_trigram(i, l, prefix):
-	prev_t = l[i-1] if i-1>=0 else '<start>'
-	next_t = l[i+1] if i+1<len(l) else '<end>'
-	mid_t = l[i] if i<len(l) else '<mid>'
-	return (prefix + ':' + '_'.join([prev_t, mid_t, next_t]), [prev_t, mid_t, next_t])
+    prev_t = l[i-1] if i-1>=0 else '<start>'
+    next_t = l[i+1] if i+1<len(l) else '<end>'
+    mid_t = l[i] if i<len(l) else '<mid>'
+    return (prefix + ':' + '_'.join([prev_t, mid_t, next_t]), [prev_t, mid_t, next_t])
 
 def process_files_whole_sentence(sentences, sentences_lpos, sentences_trees):
-	all_instances = []
-	sentence_id = 0
-	tagger_output = True
-	for sentence, lpos, tree in zip(sentences, sentences_lpos, sentences_trees):
-		sentence_ori = sentence.replace('*', '').split(' ')
-		sentence = sentence.split(' ')
-		lpos_all = [x.split('|') for x in lpos.split(' ')]
-		lpos = [x.split('|')[1] for x in lpos.split(' ')]
-		nodes = stanford_parse.parse_tree(tree)
-		
-		instance_features = []
+    all_instances = []
+    sentence_id = 0
+    tagger_output = True
+    for sentence, lpos, tree in zip(sentences, sentences_lpos, sentences_trees):
+        sentence_ori = sentence.replace('*', '').split(' ')
+        sentence = sentence.split(' ')
+        lpos_all = [x.split('|') for x in lpos.split(' ')]
+        lpos = [x.split('|')[1] for x in lpos.split(' ')]
+        nodes = stanford_parse.parse_tree(tree)
 
-		for i in range(0, len(sentence)):
-			if include_wordtrigram:
-				wordtrigram = get_trigram(i, sentence_ori, 'WORDTRI')
-				instance_features.append(wordtrigram[0])
-				instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][:2]))
-				instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][1:]))
-				instance_features.append('WORDTRI:' + wordtrigram[1][1])
+        instance_features = []
 
-			if include_postrigram:
-				postrigram = get_trigram(i, lpos, 'POSTRI')
-				instance_features.append(postrigram[0])
-				instance_features.append('POSTRI:' + '_'.join(postrigram[1][:2]))
-				instance_features.append('POSTRI:' + '_'.join(postrigram[1][1:]))
-				instance_features.append('POSTRI:' + postrigram[1][1])
+        for i in range(0, len(sentence)):
+            if include_wordtrigram:
+                wordtrigram = get_trigram(i, sentence_ori, 'WORDTRI')
+                instance_features.append(wordtrigram[0])
+                instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][:2]))
+                instance_features.append('WORDTRI:' + '_'.join(wordtrigram[1][1:]))
+                instance_features.append('WORDTRI:' + wordtrigram[1][1])
 
-		if include_nodetrigram:
-			for n in nodes:
-				if n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
-					s_node = n
-					node_indexs = range(len(s_node.children))
-					for i in node_indexs:
-						temp_trigram = []
-						temp_word_trigram = []
-						temp_node_trigram = []
-						if i-1>=0:
-							temp_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output))
-							temp_word_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output, True))
-							temp_node_trigram.append(s_node.children[i-1])
-						else:
-							temp_trigram.append('<start>')
-							temp_word_trigram.append('<start>')
-						temp_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output))
-						temp_word_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output, True))
-						temp_node_trigram.append(s_node.children[i])
-						if i+1<len(s_node.children):
-							temp_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output))
-							temp_word_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output, True))
-							temp_node_trigram.append(s_node.children[i+1])
-						else:
-							temp_trigram.append('<end>')
-							temp_word_trigram.append('<end>')
+            if include_postrigram:
+                postrigram = get_trigram(i, lpos, 'POSTRI')
+                instance_features.append(postrigram[0])
+                instance_features.append('POSTRI:' + '_'.join(postrigram[1][:2]))
+                instance_features.append('POSTRI:' + '_'.join(postrigram[1][1:]))
+                instance_features.append('POSTRI:' + postrigram[1][1])
 
-						instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:3]))
-						instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:3]))
+        if include_nodetrigram:
+            for n in nodes:
+                if n.label in ['S', 'SBAR', 'SINV', 'FRAG']:
+                    s_node = n
+                    node_indexs = range(len(s_node.children))
+                    for i in node_indexs:
+                        temp_trigram = []
+                        temp_word_trigram = []
+                        temp_node_trigram = []
+                        if i-1>=0:
+                            temp_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output))
+                            temp_word_trigram.append(get_node_with_pos(s_node.children[i-1], lpos_all, tagger_output, True))
+                            temp_node_trigram.append(s_node.children[i-1])
+                        else:
+                            temp_trigram.append('<start>')
+                            temp_word_trigram.append('<start>')
+                        temp_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output))
+                        temp_word_trigram.append(get_node_with_pos(s_node.children[i], lpos_all, tagger_output, True))
+                        temp_node_trigram.append(s_node.children[i])
+                        if i+1<len(s_node.children):
+                            temp_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output))
+                            temp_word_trigram.append(get_node_with_pos(s_node.children[i+1], lpos_all, tagger_output, True))
+                            temp_node_trigram.append(s_node.children[i+1])
+                        else:
+                            temp_trigram.append('<end>')
+                            temp_word_trigram.append('<end>')
 
-						instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:2]))
-						instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:2]))
-						
-						instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[1:]))
-						instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[1:]))
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:3]))
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:3]))
 
-						instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:1]))
-						instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:1]))
-							
-		sva_flag = '0'
-		if '*' in ' '.join(sentence):
-			sva_flag = '1'
-		instance_features = list(set(instance_features))
-		all_instances.append((instance_features, sva_flag, sentence_id, 0, sentence))
-		sentence_id += 1
-	return all_instances
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:2]))
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:2]))
+
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[1:]))
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[1:]))
+
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_trigram[:1]))
+                        instance_features.append(s_node.label + '||' + '_'.join(temp_word_trigram[:1]))
+
+        sva_flag = '0'
+        if '*' in ' '.join(sentence):
+            sva_flag = '1'
+        instance_features = list(set(instance_features))
+        all_instances.append((instance_features, sva_flag, sentence_id, 0, sentence))
+        sentence_id += 1
+    return all_instances
 
 def process_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0):
-	print( "processing file {}...".format(file_list[0]) )
-	sentences = open(file_list[0]).read().splitlines()
-	sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
-	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
-	if filter_func:
-		sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees,
-													  neg_pos_ratio, no_of_sentence, start_from)
-	return feature_function(sentences, sentences_lpos, sentences_trees)
+    print( "processing file {}...".format(file_list[0]) )
+    sentences = open(file_list[0]).read().splitlines()
+    sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
+    sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
+    if filter_func:
+        sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from)
+    return feature_function(sentences, sentences_lpos, sentences_trees)
 
 def process_training_files(file_list, feature_function, filter_func=None, neg_pos_ratio=1, no_of_sentence=10000, start_from=0, align=False):
-	print( "processing file {}...".format(file_list[0]) )
-	no_of_sentence_for_preprocess = 18000
-	sentences = open(file_list[0]).read().splitlines()
-	sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
-	sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
-	
-	no_of_pos = no_of_sentence/(neg_pos_ratio+1)
-	no_of_neg = no_of_pos * neg_pos_ratio
+    print( "processing file {}...".format(file_list[0]) )
+    no_of_sentence_for_preprocess = 18000
+    sentences = open(file_list[0]).read().splitlines()
+    sentences_lpos = open(file_list[1].replace('.txt', '_lpos.txt')).read().splitlines()
+    sentences_trees = stanford_parse.get_trees_from_raw(open(file_list[1].replace('.txt', '_trees.txt')).read())
 
-	if filter_func:
-		sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees,
-													  1, no_of_sentence_for_preprocess, start_from)
-	all_instances = feature_function(sentences, sentences_lpos, sentences_trees)
-	if align:
-		aligned_file = open(file_list[1].replace('.txt', '_align.txt')).read().splitlines()
-		aligned_file = [x.split(' ') for x in aligned_file]
+    no_of_pos = no_of_sentence/(neg_pos_ratio+1)
+    no_of_neg = no_of_pos * neg_pos_ratio
 
-	all_instances = dict([((x[2], x[3]), x) for x in all_instances])
+    if filter_func:
+        sentences, sentences_lpos, sentences_trees = filter_func(sentences, sentences_lpos, sentences_trees, 1, no_of_sentence_for_preprocess, start_from)
+    all_instances = feature_function(sentences, sentences_lpos, sentences_trees)
+    if align:
+        aligned_file = open(file_list[1].replace('.txt', '_align.txt')).read().splitlines()
+        aligned_file = [x.split(' ') for x in aligned_file]
 
-	filtered_all_instances = []
-	neg_instances = []
-	for x in all_instances.keys():
-		if all_instances[x][1] == '1':
-			if x[0]%2:			# odd number, incorrect
-				aligned_sent = x[0]-1
-			else:
-				aligned_sent = x[0]+1
-			aligned_ind = int(aligned_file[x[0]][x[1]])
-			if (aligned_sent, aligned_ind) in all_instances.keys():
-				current_instance = all_instances[x]
-				aligned_instance = all_instances[(aligned_sent, aligned_ind)]
-				if current_instance[1] != aligned_instance[1]:
-					current_local_features = [x for x in current_instance[0] if "WORDTRI:" in x or "POSTRI:" in x]
-					current_parse_features = [x for x in current_instance[0] if "WORDTRI:" not in x and "POSTRI:" not in x]
-					aligned_local_features = [x for x in aligned_instance[0] if "WORDTRI:" in x or "POSTRI:" in x]
-					aligned_parse_features = [x for x in aligned_instance[0] if "WORDTRI:" not in x and "POSTRI:" not in x]
-					temp = list(set(current_parse_features) - set(aligned_parse_features))
-					aligned_instance[0] = list(set(aligned_parse_features) - set(current_parse_features)) + aligned_local_features
-					current_instance[0] = temp + current_local_features
-					if len(filtered_all_instances) < no_of_pos:
-						filtered_all_instances.append(current_instance)
-					if len(neg_instances) < no_of_neg:
-						neg_instances.append(aligned_instance)
-					else:
-						break
-	
-	print( "Training data (filtered):" )
-	print( "no of pos: {}".format(len(filtered_all_instances)) )
-	print( "no of neg: {}".format(len(neg_instances)) )
-	filtered_all_instances += neg_instances
-	return filtered_all_instances
+    all_instances = dict([((x[2], x[3]), x) for x in all_instances])
+
+    filtered_all_instances = []
+    neg_instances = []
+    for x in all_instances.keys():
+        if all_instances[x][1] == '1':
+            if x[0]%2:                      # odd number, incorrect
+                aligned_sent = x[0]-1
+            else:
+                aligned_sent = x[0]+1
+            aligned_ind = int(aligned_file[x[0]][x[1]])
+            if (aligned_sent, aligned_ind) in all_instances.keys():
+                current_instance = all_instances[x]
+                aligned_instance = all_instances[(aligned_sent, aligned_ind)]
+                if current_instance[1] != aligned_instance[1]:
+                    current_local_features = [x for x in current_instance[0] if "WORDTRI:" in x or "POSTRI:" in x]
+                    current_parse_features = [x for x in current_instance[0] if "WORDTRI:" not in x and "POSTRI:" not in x]
+                    aligned_local_features = [x for x in aligned_instance[0] if "WORDTRI:" in x or "POSTRI:" in x]
+                    aligned_parse_features = [x for x in aligned_instance[0] if "WORDTRI:" not in x and "POSTRI:" not in x]
+                    temp = list(set(current_parse_features) - set(aligned_parse_features))
+                    aligned_instance[0] = list(set(aligned_parse_features) - set(current_parse_features)) + aligned_local_features
+                    current_instance[0] = temp + current_local_features
+                    if len(filtered_all_instances) < no_of_pos:
+                        filtered_all_instances.append(current_instance)
+                    if len(neg_instances) < no_of_neg:
+                        neg_instances.append(aligned_instance)
+                    else:
+                        break
+
+    print( "Training data (filtered):" )
+    print( "no of pos: {}".format(len(filtered_all_instances)) )
+    print( "no of neg: {}".format(len(neg_instances)) )
+    filtered_all_instances += neg_instances
+    return filtered_all_instances
 
 
 def training_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from):
-	new_sentences = []
-	new_sentences_lpos = []
-	new_sentences_trees = []
-	no_of_pos = round(no_of_sentence/(neg_pos_ratio+1))
-	no_of_neg = round(no_of_pos * neg_pos_ratio)
-	print( "Training data (preprocess):" )
-	count = 0
-	pos_count = 0
-	neg_count = 0
-	for sentence, lpos, tree in zip(sentences[start_from:], sentences_lpos[start_from:], sentences_trees[start_from:]):
-		if no_of_pos == 0 and no_of_neg == 0:
-			break
-		if '*' in sentence:
-			if no_of_pos > 0:
-				new_sentences.append(sentence)
-				new_sentences_lpos.append(lpos)
-				new_sentences_trees.append(tree)
-				no_of_pos -= 1
-				pos_count += 1
-		else:
-			if no_of_neg > 0:
-				new_sentences.append(sentence)
-				new_sentences_lpos.append(lpos)
-				new_sentences_trees.append(tree)
-				no_of_neg -= 1	
-				neg_count += 1
-		count += 1
-	
-	print( "no of pos: {}".format(pos_count) )
-	print( "no of neg: {}".format(neg_count)	 )
-	print( len(new_sentences) )
-	print( start_from )
-	print( count	 )
-	print( start_from + count )
-	return (new_sentences, new_sentences_lpos, new_sentences_trees)
+    new_sentences = []
+    new_sentences_lpos = []
+    new_sentences_trees = []
+    no_of_pos = round(no_of_sentence/(neg_pos_ratio+1))
+    no_of_neg = round(no_of_pos * neg_pos_ratio)
+    print( "Training data (preprocess):" )
+    count = 0
+    pos_count = 0
+    neg_count = 0
+    for sentence, lpos, tree in zip(sentences[start_from:], sentences_lpos[start_from:], sentences_trees[start_from:]):
+        if no_of_pos == 0 and no_of_neg == 0:
+            break
+        if '*' in sentence:
+            if no_of_pos > 0:
+                new_sentences.append(sentence)
+                new_sentences_lpos.append(lpos)
+                new_sentences_trees.append(tree)
+                no_of_pos -= 1
+                pos_count += 1
+        else:
+            if no_of_neg > 0:
+                new_sentences.append(sentence)
+                new_sentences_lpos.append(lpos)
+                new_sentences_trees.append(tree)
+                no_of_neg -= 1
+                neg_count += 1
+        count += 1
+
+    print( "no of pos: {}".format(pos_count) )
+    print( "no of neg: {}".format(neg_count)         )
+    print( len(new_sentences) )
+    print( start_from )
+    print( count     )
+    print( start_from + count )
+    return (new_sentences, new_sentences_lpos, new_sentences_trees)
 
 def nucle_data_filter(sentences, sentences_lpos, sentences_trees, neg_pos_ratio, no_of_sentence, start_from):
-	return (sentences, sentences_lpos, sentences_trees)
+    return (sentences, sentences_lpos, sentences_trees)
 
 def show_most_informative_features_binary(vectorizer, clf, n=20):
     feature_names = vectorizer.get_feature_names()
@@ -455,26 +453,26 @@ def show_most_informative_features_binary(vectorizer, clf, n=20):
         print( "\t%.4f\t%-15s\t\t%.4f\t%-15s" % (coef_1, fn_1, coef_2, fn_2) )
 
 if __name__ == '__main__':
-	
-	include_wordtrigram = False
-	include_postrigram = False
-	include_nodetrigram = True
 
-	feauture_function = process_files_whole_sentence
+    include_wordtrigram = False
+    include_postrigram = False
+    include_nodetrigram = True
 
-	# pos_neg_ratio
-	r = 1
-	
-	print( "ratio: {}".format(r) )
-	print( 'word: {}'.format(include_wordtrigram) )
-	print( 'pos: {}'.format(include_postrigram) )
-	print( 'node: {}'.format(include_nodetrigram) )
-	all_instances = process_files(DATA['nucle_frag_f'], feauture_function, training_data_filter, neg_pos_ratio=r)
-	features_set, classifier = train_maxent(all_instances)
-	
+    feauture_function = process_files_whole_sentence
 
-	show_most_informative_features_binary(classifier._vectorizer, classifier._clf, n=100)
+    # pos_neg_ratio
+    r = 1
 
-	all_instances = process_files(DATA['nucle_frag_f'], feauture_function)
+    print( "ratio: {}".format(r) )
+    print( 'word: {}'.format(include_wordtrigram) )
+    print( 'pos: {}'.format(include_postrigram) )
+    print( 'node: {}'.format(include_nodetrigram) )
+    all_instances = process_files(DATA['nucle_frag_f'], feauture_function, training_data_filter, neg_pos_ratio=r)
+    features_set, classifier = train_maxent(all_instances)
 
-	sig_out = test_maxent(classifier, features_set, all_instances)
+
+    show_most_informative_features_binary(classifier._vectorizer, classifier._clf, n=100)
+
+    all_instances = process_files(DATA['nucle_frag_f'], feauture_function)
+
+    sig_out = test_maxent(classifier, features_set, all_instances)

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 from sklearn.linear_model import LogisticRegression
 from nltk.classify.scikitlearn import SklearnClassifier
 import stanford_parse

--- a/script/frag_detection.py
+++ b/script/frag_detection.py
@@ -25,7 +25,31 @@ best_ratio = {
 prob_list = [0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95]
 
 
-FIND_HEAD_DICT = {'ADJP':(0,['NNS','QP','NN','ADVP','JJ','VBN','VBG','ADJP','JJR','NP','JJS','DT','FW','RBR','RBS','SBAR','RB']),'ADVP':(1,['RB','RBR','RBS','FW','ADVP','TO','CD','JJR','JJ','IN','NP','JJS','NN']),'CONJP':(1,['CC','RB','IN']),'FRAG':(1,[]),'INTJ':(0,[]),'LST':(1,['LS']),'NAC':(0,['NN','NNS','NNP','NNPS','NP','NAC','EX','CD','QP','PRP','VBG','JJ','JJS','JJR','ADJP','FW']),'PP':(1,['IN','TO','VBG','VBN','RP','FW']),'PRN':(0,[]),'PRT':(1,['RP']),'QP':(0,['$','IN','NNS','NN','JJ','RB','DT','CD','NCD','QP','JJR','JJS']),'RRC':(1,['VP','NP','ADVP','ADJP','PP']),'S':(0,['TO','IN','VP','S','SBAR','ADJP','UCP','NP']),'SBAR':(0,['WHNP','WHPP','WHADVP','WHADJP','IN','DT','S','SQ','SINV','SBAR','FRAG']),'SBARQ':(0,['SQ','S','SINV','SBARQ','FRAG']),'SINV':(0,['VBZ','VBD','VBP','VB','MD','VP','S','SINV','ADJP','NP']),'SQ':(0,['VBZ','VBD','VBP','VB','MD','VP','SQ']),'UCP':(1,[]),'VP':(0,['TO','VBD','VBN','MD','VBZ','VB','VBG','VBP','VP','ADJP','NN','NNS','NP']),'WHADJP':(0,['CC','WRB','JJ','ADJP']),'WHADVP':(1,['CC','WRB']),'WHNP':(0,['WDT','WP','WP$','WHADJP','WHPP','WHNP']),'WHPP':(1,['IN','TO','FW'])}
+FIND_HEAD_DICT = {
+    'ADJP': (0, ['NNS', 'QP', 'NN', 'ADVP', 'JJ', 'VBN', 'VBG', 'ADJP', 'JJR', 'NP', 'JJS', 'DT', 'FW', 'RBR', 'RBS', 'SBAR', 'RB']),
+    'ADVP': (1, ['RB', 'RBR', 'RBS', 'FW', 'ADVP', 'TO', 'CD', 'JJR', 'JJ', 'IN', 'NP', 'JJS', 'NN']),
+    'CONJP': (1, ['CC', 'RB', 'IN']),
+    'FRAG': (1, []),
+    'INTJ': (0, []),
+    'LST': (1, ['LS']),
+    'NAC': (0, ['NN', 'NNS', 'NNP', 'NNPS', 'NP', 'NAC', 'EX', 'CD', 'QP', 'PRP', 'VBG', 'JJ', 'JJS', 'JJR', 'ADJP', 'FW']),
+    'PP': (1, ['IN', 'TO', 'VBG', 'VBN', 'RP', 'FW']),
+    'PRN': (0, []),
+    'PRT': (1, ['RP']),
+    'QP': (0, ['$', 'IN', 'NNS', 'NN', 'JJ', 'RB', 'DT', 'CD', 'NCD', 'QP', 'JJR', 'JJS']),
+    'RRC': (1, ['VP', 'NP', 'ADVP', 'ADJP', 'PP']),
+    'S': (0, ['TO', 'IN', 'VP', 'S', 'SBAR', 'ADJP', 'UCP', 'NP']),
+    'SBAR': (0, ['WHNP', 'WHPP', 'WHADVP', 'WHADJP', 'IN', 'DT', 'S', 'SQ', 'SINV', 'SBAR', 'FRAG']),
+    'SBARQ': (0, ['SQ', 'S', 'SINV', 'SBARQ', 'FRAG']),
+    'SINV': (0, ['VBZ', 'VBD', 'VBP', 'VB', 'MD', 'VP', 'S', 'SINV', 'ADJP', 'NP']),
+    'SQ': (0, ['VBZ', 'VBD', 'VBP', 'VB', 'MD', 'VP', 'SQ']),
+    'UCP': (1, []),
+    'VP': (0, ['TO', 'VBD', 'VBN', 'MD', 'VBZ', 'VB', 'VBG', 'VBP', 'VP', 'ADJP', 'NN', 'NNS', 'NP']),
+    'WHADJP': (0, ['CC', 'WRB', 'JJ', 'ADJP']),
+    'WHADVP': (1, ['CC', 'WRB']),
+    'WHNP': (0, ['WDT', 'WP', 'WP$', 'WHADJP', 'WHPP', 'WHNP']),
+    'WHPP': (1, ['IN', 'TO', 'FW']),
+}
 
 convert_noun = False
 print_error = False

--- a/script/stanford_parse.py
+++ b/script/stanford_parse.py
@@ -39,7 +39,7 @@ class Node:
                 break
         return out
 
-    def match_children(self, l, find_last = False):
+    def match_children(self, l, find_last=False):
         out = None
         for x in self.children:
             if l in x.label:
@@ -64,7 +64,7 @@ class Node:
                     break
         return out
 
-    def match_children_recursive(self, l, find_last = False):
+    def match_children_recursive(self, l, find_last=False):
         out = self.match_children(l, find_last)
         if out == None:
             for x in self.children:

--- a/script/stanford_parse.py
+++ b/script/stanford_parse.py
@@ -50,7 +50,7 @@ class Node:
 
     def check_and_get_child(self, index, l):
         out = None
-        if len(self.children)>index and self.children[index].label in l:
+        if len(self.children) > index and self.children[index].label in l:
             out = self.children[index]
         return out
 
@@ -98,7 +98,7 @@ def search_tree(tree, word_list):
             is_word = False
             if word.strip() != '':
                 words.append(word.strip())
-                if len(target)> 0 and word == target[0]:
+                if len(target) > 0 and word == target[0]:
                     target.pop(0)
                     if len(target) == 0:
                         output2 = level[-1]
@@ -144,7 +144,7 @@ def search_label(tree, word_list):
             is_word = False
             if word.strip() != '':
                 words.append(word.strip())
-                if len(target)> 0 and word == target[0]:
+                if len(target) > 0 and word == target[0]:
                     target.pop(0)
                     if len(target) == 0:
                         output = out[level[-1]][0]
@@ -222,7 +222,7 @@ def convert_tree(tree, words):
         nodes[i].label = x[0]
         nodes[i].word_index = x[2]
         nodes[i].children = [nodes[k] for k in x[1]]
-        if len(word_indexes)>0 and x[2] == word_indexes[0] and len(x[1])==0:
+        if len(word_indexes) > 0 and x[2] == word_indexes[0] and len(x[1]) == 0:
             word_indexes.pop(0)
             nodes[i].word = temp_words.pop(0)
         for j, y in enumerate(x[1]):

--- a/script/stanford_parse.py
+++ b/script/stanford_parse.py
@@ -1,244 +1,244 @@
 import re
 
 class Node:
-	def __init__(self):
-		self.label = ''
-		self.parent = -100
-		self.parent_n = None
-		self.elder_siblings = []
-		self.younger_siblings = []
-		self.children = []
-		self.word = ''
-		self.word_index = -100
-		self.id = ''
+    def __init__(self):
+        self.label = ''
+        self.parent = -100
+        self.parent_n = None
+        self.elder_siblings = []
+        self.younger_siblings = []
+        self.children = []
+        self.word = ''
+        self.word_index = -100
+        self.id = ''
 
-	def search_self_and_younger_siblings(self, l):
-		out = None
-		if self.label in l:
-			out = self
-		else:
-			for x in self.younger_siblings:
-				if x.label in l:
-					out = x
-					break
-		return out
-		
-	def search_younger_siblings(self, l):
-		out = None
-		for x in self.younger_siblings:
-			if x.label in l:
-				out = x
-				break
-		return out	
-		
-	def search_children(self, l):		
-		out = None
-		for x in self.children:
-			if x.label in l:
-				out = x
-				break
-		return out
-		
-	def match_children(self, l, find_last = False):		
-		out = None
-		for x in self.children:
-			if l in x.label:
-				out = x
-				if not find_last:
-					break
-		return out	
-		
-	def check_and_get_child(self, index, l):		
-		out = None
-		if len(self.children)>index and self.children[index].label in l:
-			out = self.children[index]
-		return out	
-		
-	def search_children_recursive(self, l):		
-		out = self.search_children(l)
-		if out == None:	
-			for x in self.children:
-				temp = x.search_children_recursive(l)
-				if temp != None:
-					out = temp
-					break
-		return out
+    def search_self_and_younger_siblings(self, l):
+        out = None
+        if self.label in l:
+            out = self
+        else:
+            for x in self.younger_siblings:
+                if x.label in l:
+                    out = x
+                    break
+        return out
 
-	def match_children_recursive(self, l, find_last = False):		
-		out = self.match_children(l, find_last)
-		if out == None:	
-			for x in self.children:
-				temp = x.match_children_recursive(l)
-				if temp != None:
-					out = temp
-					if not find_last:
-						break
-		return out
-	
-		
+    def search_younger_siblings(self, l):
+        out = None
+        for x in self.younger_siblings:
+            if x.label in l:
+                out = x
+                break
+        return out
+
+    def search_children(self, l):
+        out = None
+        for x in self.children:
+            if x.label in l:
+                out = x
+                break
+        return out
+
+    def match_children(self, l, find_last = False):
+        out = None
+        for x in self.children:
+            if l in x.label:
+                out = x
+                if not find_last:
+                    break
+        return out
+
+    def check_and_get_child(self, index, l):
+        out = None
+        if len(self.children)>index and self.children[index].label in l:
+            out = self.children[index]
+        return out
+
+    def search_children_recursive(self, l):
+        out = self.search_children(l)
+        if out == None:
+            for x in self.children:
+                temp = x.search_children_recursive(l)
+                if temp != None:
+                    out = temp
+                    break
+        return out
+
+    def match_children_recursive(self, l, find_last = False):
+        out = self.match_children(l, find_last)
+        if out == None:
+            for x in self.children:
+                temp = x.match_children_recursive(l)
+                if temp != None:
+                    out = temp
+                    if not find_last:
+                        break
+        return out
+
+
 def search_tree(tree, word_list):
-	target = word_list[:]
-	retrieve = False
-	out = []
-	words = []
-	level = [-1,]
-	label = ''
-	is_label = False
-	is_word = True
-	word = ''
-	output = ''
-	output2 = -123
-	for x in tree:
-		if x == '(':
-			level.append(len(out))
-			is_label = True
-			is_word = False
-			word = ''
-		elif x == ')':
-			is_word = False
-			if word.strip() != '':
-				words.append(word.strip())
-				if len(target)> 0 and word == target[0]:
-					target.pop(0)
-					if len(target) == 0:
-						output2 = level[-1]
-						retrieve = True
-			word = ''
-			temp = level.pop()
-			out[temp][2] = len(words)
-		elif is_label:
-			if x == ' ':
-				is_label = False
-				out.append([label, [], 0, len(out)])
-				if retrieve:
-					output = label
-					retrieve = False
-				if level[-2] >= 0:
-					out[level[-2]][1].append(len(out)-1)
-				label = ''
-				is_word = True
-			else:
-				label += x
-		elif is_word:
-			word += x
-	return output2
+    target = word_list[:]
+    retrieve = False
+    out = []
+    words = []
+    level = [-1,]
+    label = ''
+    is_label = False
+    is_word = True
+    word = ''
+    output = ''
+    output2 = -123
+    for x in tree:
+        if x == '(':
+            level.append(len(out))
+            is_label = True
+            is_word = False
+            word = ''
+        elif x == ')':
+            is_word = False
+            if word.strip() != '':
+                words.append(word.strip())
+                if len(target)> 0 and word == target[0]:
+                    target.pop(0)
+                    if len(target) == 0:
+                        output2 = level[-1]
+                        retrieve = True
+            word = ''
+            temp = level.pop()
+            out[temp][2] = len(words)
+        elif is_label:
+            if x == ' ':
+                is_label = False
+                out.append([label, [], 0, len(out)])
+                if retrieve:
+                    output = label
+                    retrieve = False
+                if level[-2] >= 0:
+                    out[level[-2]][1].append(len(out)-1)
+                label = ''
+                is_word = True
+            else:
+                label += x
+        elif is_word:
+            word += x
+    return output2
 
 def search_label(tree, word_list):
-	target = word_list[:]
-	retrieve = False
-	out = []
-	words = []
-	level = [-1,]
-	label = ''
-	is_label = False
-	is_word = True
-	word = ''
-	output = ''
-	for x in tree:
-		if x == '(':
-			level.append(len(out))
-			is_label = True
-			is_word = False
-			word = ''
-		elif x == ')':
-			is_word = False
-			if word.strip() != '':
-				words.append(word.strip())
-				if len(target)> 0 and word == target[0]:
-					target.pop(0)
-					if len(target) == 0:
-						output = out[level[-1]][0]
-						break
-			word = ''
-			temp = level.pop()
-			out[temp][2] = len(words)
-		elif is_label:
-			if x == ' ':
-				is_label = False
-				out.append([label, [], 0, len(out)])
-				if retrieve:
-					output = label
-					retrieve = False
-					#break
-				if level[-2] >= 0:
-					out[level[-2]][1].append(len(out)-1)
-				label = ''
-				is_word = True
-			else:
-				label += x
-		elif is_word:
-			word += x
-	return output
+    target = word_list[:]
+    retrieve = False
+    out = []
+    words = []
+    level = [-1,]
+    label = ''
+    is_label = False
+    is_word = True
+    word = ''
+    output = ''
+    for x in tree:
+        if x == '(':
+            level.append(len(out))
+            is_label = True
+            is_word = False
+            word = ''
+        elif x == ')':
+            is_word = False
+            if word.strip() != '':
+                words.append(word.strip())
+                if len(target)> 0 and word == target[0]:
+                    target.pop(0)
+                    if len(target) == 0:
+                        output = out[level[-1]][0]
+                        break
+            word = ''
+            temp = level.pop()
+            out[temp][2] = len(words)
+        elif is_label:
+            if x == ' ':
+                is_label = False
+                out.append([label, [], 0, len(out)])
+                if retrieve:
+                    output = label
+                    retrieve = False
+                    #break
+                if level[-2] >= 0:
+                    out[level[-2]][1].append(len(out)-1)
+                label = ''
+                is_word = True
+            else:
+                label += x
+        elif is_word:
+            word += x
+    return output
 
 
 def parse_tree_with_words(tree):
-	out = []
-	words = []
-	level = [-1,]
-	label = ''
-	is_label = False
-	is_word = True
-	word = ''
-	for x in tree:
-		if x == '(':
-			level.append(len(out))
-			is_label = True
-			is_word = False
-			word = ''
-		elif x == ')':
-			is_word = False
-			if word.strip() != '':
-				words.append(word.strip())
-			word = ''
-			temp = level.pop()
-			out[temp][2] = len(words)
-		elif is_label:
-			if x == ' ':
-				is_label = False
-				out.append([label, [], 0])
-				if level[-2] >= 0:
-					out[level[-2]][1].append(len(out)-1)
-				label = ''
-				is_word = True
-			else:
-				label += x
-		elif is_word:
-			word += x
-	return (out, words)
+    out = []
+    words = []
+    level = [-1,]
+    label = ''
+    is_label = False
+    is_word = True
+    word = ''
+    for x in tree:
+        if x == '(':
+            level.append(len(out))
+            is_label = True
+            is_word = False
+            word = ''
+        elif x == ')':
+            is_word = False
+            if word.strip() != '':
+                words.append(word.strip())
+            word = ''
+            temp = level.pop()
+            out[temp][2] = len(words)
+        elif is_label:
+            if x == ' ':
+                is_label = False
+                out.append([label, [], 0])
+                if level[-2] >= 0:
+                    out[level[-2]][1].append(len(out)-1)
+                label = ''
+                is_word = True
+            else:
+                label += x
+        elif is_word:
+            word += x
+    return (out, words)
 
 
 def parse_tree(tree):
-	temp = parse_tree_with_words(tree)
-	return convert_tree(temp[0], temp[1])
-	
+    temp = parse_tree_with_words(tree)
+    return convert_tree(temp[0], temp[1])
+
 def convert_tree(tree, words):
-	nodes = []
-	temp_words = words[:]
-	word_indexes = list(range(1, len(words)+1))
-	for x in tree:
-		nodes.append(Node())
-	for i, x in enumerate(tree):
-		nodes[i].id = i
-		nodes[i].label = x[0]
-		nodes[i].word_index = x[2]
-		nodes[i].children = [nodes[k] for k in x[1]]
-		if len(word_indexes)>0 and x[2] == word_indexes[0] and len(x[1])==0:
-			word_indexes.pop(0)
-			nodes[i].word = temp_words.pop(0)
-		for j, y in enumerate(x[1]):
-			nodes[y].parent = i
-			nodes[y].parent_n = nodes[i]
-			nodes[y].elder_siblings = [nodes[k] for k in x[1][:j]]
-			nodes[y].younger_siblings = [nodes[k] for k in x[1][j+1:]]
-	return nodes
+    nodes = []
+    temp_words = words[:]
+    word_indexes = list(range(1, len(words)+1))
+    for x in tree:
+        nodes.append(Node())
+    for i, x in enumerate(tree):
+        nodes[i].id = i
+        nodes[i].label = x[0]
+        nodes[i].word_index = x[2]
+        nodes[i].children = [nodes[k] for k in x[1]]
+        if len(word_indexes)>0 and x[2] == word_indexes[0] and len(x[1])==0:
+            word_indexes.pop(0)
+            nodes[i].word = temp_words.pop(0)
+        for j, y in enumerate(x[1]):
+            nodes[y].parent = i
+            nodes[y].parent_n = nodes[i]
+            nodes[y].elder_siblings = [nodes[k] for k in x[1][:j]]
+            nodes[y].younger_siblings = [nodes[k] for k in x[1][j+1:]]
+    return nodes
 
 def tree_sub_func(matchobj):
-	return "|" + matchobj.group(0)
-	
+    return "|" + matchobj.group(0)
+
 def get_trees_from_raw(trees_raw, flat=True):
-	trees = trees_raw
-	if flat:
-		trees = trees.replace('\n', '')
-	trees = re.sub(r"\(ROOT", tree_sub_func, trees)
-	trees = trees.split('|')[1:]
-	return trees
+    trees = trees_raw
+    if flat:
+        trees = trees.replace('\n', '')
+    trees = re.sub(r"\(ROOT", tree_sub_func, trees)
+    trees = trees.split('|')[1:]
+    return trees

--- a/script/stanford_parse.py
+++ b/script/stanford_parse.py
@@ -56,7 +56,7 @@ class Node:
 
     def search_children_recursive(self, l):
         out = self.search_children(l)
-        if out == None:
+        if out is None:
             for x in self.children:
                 temp = x.search_children_recursive(l)
                 if temp != None:
@@ -66,7 +66,7 @@ class Node:
 
     def match_children_recursive(self, l, find_last=False):
         out = self.match_children(l, find_last)
-        if out == None:
+        if out is None:
             for x in self.children:
                 temp = x.match_children_recursive(l)
                 if temp != None:

--- a/script/stanford_parse.py
+++ b/script/stanford_parse.py
@@ -12,7 +12,7 @@ class Node:
 		self.word_index = -100
 		self.id = ''
 
-	def search_self_and_younger_siblings(self,l):
+	def search_self_and_younger_siblings(self, l):
 		out = None
 		if self.label in l:
 			out = self
@@ -23,7 +23,7 @@ class Node:
 					break
 		return out
 		
-	def search_younger_siblings(self,l):
+	def search_younger_siblings(self, l):
 		out = None
 		for x in self.younger_siblings:
 			if x.label in l:
@@ -31,7 +31,7 @@ class Node:
 				break
 		return out	
 		
-	def search_children(self,l):		
+	def search_children(self, l):		
 		out = None
 		for x in self.children:
 			if x.label in l:
@@ -39,7 +39,7 @@ class Node:
 				break
 		return out
 		
-	def match_children(self,l,find_last = False):		
+	def match_children(self, l, find_last = False):		
 		out = None
 		for x in self.children:
 			if l in x.label:
@@ -48,13 +48,13 @@ class Node:
 					break
 		return out	
 		
-	def check_and_get_child(self,index,l):		
+	def check_and_get_child(self, index, l):		
 		out = None
 		if len(self.children)>index and self.children[index].label in l:
 			out = self.children[index]
 		return out	
 		
-	def search_children_recursive(self,l):		
+	def search_children_recursive(self, l):		
 		out = self.search_children(l)
 		if out == None:	
 			for x in self.children:
@@ -64,8 +64,8 @@ class Node:
 					break
 		return out
 
-	def match_children_recursive(self,l,find_last = False):		
-		out = self.match_children(l,find_last)
+	def match_children_recursive(self, l, find_last = False):		
+		out = self.match_children(l, find_last)
 		if out == None:	
 			for x in self.children:
 				temp = x.match_children_recursive(l)
@@ -76,7 +76,7 @@ class Node:
 		return out
 	
 		
-def search_tree(tree,word_list):
+def search_tree(tree, word_list):
 	target = word_list[:]
 	retrieve = False
 	out = []
@@ -109,7 +109,7 @@ def search_tree(tree,word_list):
 		elif is_label:
 			if x == ' ':
 				is_label = False
-				out.append([label,[],0,len(out)])
+				out.append([label, [], 0, len(out)])
 				if retrieve:
 					output = label
 					retrieve = False
@@ -123,7 +123,7 @@ def search_tree(tree,word_list):
 			word += x
 	return output2
 
-def search_label(tree,word_list):
+def search_label(tree, word_list):
 	target = word_list[:]
 	retrieve = False
 	out = []
@@ -155,7 +155,7 @@ def search_label(tree,word_list):
 		elif is_label:
 			if x == ' ':
 				is_label = False
-				out.append([label,[],0,len(out)])
+				out.append([label, [], 0, len(out)])
 				if retrieve:
 					output = label
 					retrieve = False
@@ -195,7 +195,7 @@ def parse_tree_with_words(tree):
 		elif is_label:
 			if x == ' ':
 				is_label = False
-				out.append([label,[],0])
+				out.append([label, [], 0])
 				if level[-2] >= 0:
 					out[level[-2]][1].append(len(out)-1)
 				label = ''
@@ -204,20 +204,20 @@ def parse_tree_with_words(tree):
 				label += x
 		elif is_word:
 			word += x
-	return (out,words)
+	return (out, words)
 
 
 def parse_tree(tree):
 	temp = parse_tree_with_words(tree)
-	return convert_tree(temp[0],temp[1])
+	return convert_tree(temp[0], temp[1])
 	
-def convert_tree(tree,words):
+def convert_tree(tree, words):
 	nodes = []
 	temp_words = words[:]
-	word_indexes = list(range(1,len(words)+1))
+	word_indexes = list(range(1, len(words)+1))
 	for x in tree:
 		nodes.append(Node())
-	for i,x in enumerate(tree):
+	for i, x in enumerate(tree):
 		nodes[i].id = i
 		nodes[i].label = x[0]
 		nodes[i].word_index = x[2]
@@ -225,7 +225,7 @@ def convert_tree(tree,words):
 		if len(word_indexes)>0 and x[2] == word_indexes[0] and len(x[1])==0:
 			word_indexes.pop(0)
 			nodes[i].word = temp_words.pop(0)
-		for j,y in enumerate(x[1]):
+		for j, y in enumerate(x[1]):
 			nodes[y].parent = i
 			nodes[y].parent_n = nodes[i]
 			nodes[y].elder_siblings = [nodes[k] for k in x[1][:j]]
@@ -238,7 +238,7 @@ def tree_sub_func(matchobj):
 def get_trees_from_raw(trees_raw, flat=True):
 	trees = trees_raw
 	if flat:
-		trees = trees.replace('\n','')
-	trees = re.sub(r"\(ROOT",tree_sub_func,trees)
+		trees = trees.replace('\n', '')
+	trees = re.sub(r"\(ROOT", tree_sub_func, trees)
 	trees = trees.split('|')[1:]
 	return trees


### PR DESCRIPTION
Further set of incremental tweaks to improve the code, as run against pylint 1.5.2. Key changes are:
- Improved readability
- Fixed import order
- Fixed indentation (4 spaces versus tabs)
- Fixed whitespace
- Fixed expr comparison to `None`, which should be via `is` rather than `==` operator
- De-blobbed the `FIND_HEAD_DICT` dict

The full set of changes in this PR see pylint 1.5.2 give the code in `script/` a score of:

```
Global evaluation
-----------------
Your code has been rated at 6.70/10
```

No changes to the key output metrics of the script when run against the provided testing data.
